### PR TITLE
[ready] users can request the current game's status

### DIFF
--- a/app/models/attendance.rb
+++ b/app/models/attendance.rb
@@ -1,4 +1,6 @@
 class Attendance < ActiveRecord::Base
   belongs_to :game
   belongs_to :player
+  validates_uniqueness_of :player_id, scope: :game_id
+
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,4 +17,5 @@ Rails.application.configure do
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "localhost:3000" }
+  default_url_options[:host] = ENV['APPLICATION_HOST']
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,5 +19,6 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
   config.active_record.dump_schema_after_migration = false
   config.action_mailer.default_url_options = { host: ENV.fetch("APPLICATION_HOST") }
+  default_url_options[:host] = ENV['APPLICATION_HOST']
 end
 Rack::Timeout.timeout = (ENV["RACK_TIMEOUT"] || 10).to_i

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,4 +14,5 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: "www.example.com" }
   config.active_job.queue_adapter = :inline
+  default_url_options[:host] = ENV['APPLICATION_HOST']
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,5 +29,5 @@ en:
         joined: "@%{username} joined the game. There are now %{players} players."
       status:
         no_game: "There's no active game, @%{username}"
-        game_status: "There's [a game](%{game_url}) with __%{players} players__. Type /join to __join__."
+        game_status: "There's [a game](%{game_url}) with *%{players} players*. Type /join to *join*."
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,3 +27,7 @@ en:
       join:
         no_game: "There's no active game, @%{username}"
         joined: "@%{username} joined the game. There are now %{players} players."
+      status:
+        no_game: "There's no active game, @%{username}"
+        game_status: "There's [a game](%{game_url}) with __%{players} players__. Type /join to __join__."
+

--- a/lib/pickup_bot.rb
+++ b/lib/pickup_bot.rb
@@ -13,6 +13,8 @@ class PickupBot
       PickupBot::Commands::CreateGame.run(telegram_bot, message)
     when /join/
       PickupBot::Commands::Join.run(telegram_bot, message)
+    when /status/
+      PickupBot::Commands::Status.run(telegram_bot, message)
     end
   end
 end

--- a/lib/pickup_bot/commands.rb
+++ b/lib/pickup_bot/commands.rb
@@ -4,3 +4,4 @@ end
 require 'pickup_bot/commands/help'
 require 'pickup_bot/commands/create_game'
 require 'pickup_bot/commands/join'
+require 'pickup_bot/commands/status'

--- a/lib/pickup_bot/commands/status.rb
+++ b/lib/pickup_bot/commands/status.rb
@@ -17,18 +17,18 @@ module Commands
       if game_exists?
         telegram_bot.api.send_message(
           chat_id: message.chat.id,
-          parse_mode: "Markdown",
+          parse_mode: "markdown",
           text: I18n.t(
-            "bot.commands.status.game_status",
-            players: players,
-            game_url: url_for(current_game),
-          )
+                  "bot.commands.status.game_status",
+                  players: players,
+                  game_url: game_url(current_game),
+                )
         )
       else
         telegram_bot.api.send_message(
           chat_id: message.chat.id,
           text: I18n.t("bot.commands.status.no_game", username: username),
-          parse_mode: "Markdown"
+          parse_mode: "markdown"
         )
       end
     end
@@ -55,10 +55,6 @@ module Commands
 
     def username
       message.from.username || message.from.first_name
-    end
-
-    def game_url
-      #
     end
   end
 end

--- a/lib/pickup_bot/commands/status.rb
+++ b/lib/pickup_bot/commands/status.rb
@@ -1,0 +1,64 @@
+module Commands
+  class Status
+    include ActionView::Helpers
+    include ActionDispatch::Routing
+    include Rails.application.routes.url_helpers
+
+    def self.run(telegram_bot, message)
+      new(telegram_bot, message).run
+    end
+
+    def initialize(telegram_bot, message)
+      @telegram_bot = telegram_bot
+      @message = message
+    end
+
+    def run
+      if game_exists?
+        telegram_bot.api.send_message(
+          chat_id: message.chat.id,
+          parse_mode: "Markdown",
+          text: I18n.t(
+            "bot.commands.status.game_status",
+            players: players,
+            game_url: url_for(current_game),
+          )
+        )
+      else
+        telegram_bot.api.send_message(
+          chat_id: message.chat.id,
+          text: I18n.t("bot.commands.status.no_game", username: username),
+          parse_mode: "Markdown"
+        )
+      end
+    end
+
+    private
+
+    attr_reader :telegram_bot, :message
+
+    def game_exists?
+      Game.exists?(chat_id: @message.chat.id)
+    end
+
+    def current_game
+      Game.find_by_chat_id(@message.chat.id)
+    end
+
+    def players
+      if current_game.required_players > 0
+        "#{current_game.players.count} / #{current_game.required_players}"
+      else
+        "#{current_game.players.count}"
+      end
+    end
+
+    def username
+      message.from.username || message.from.first_name
+    end
+
+    def game_url
+      #
+    end
+  end
+end

--- a/spec/lib/pickup_bot/commands/status_spec.rb
+++ b/spec/lib/pickup_bot/commands/status_spec.rb
@@ -36,13 +36,10 @@ feature "checking a game's status" do
     scenario "user tries to assess the game's status" do
       message = Telegram::Bot::Types::Message.new(message_params("/status"))
       game = Game.create(chat_id: fake_chat_id, required_players: 5)
+      default_url_options[:host] = ENV['APPLICATION_HOST']
       game.reload # to pull the UUID
-      game_url = url_for(game)
 
-      pp game_url # this outputs www.example.com/path/to/game,
-                  # but in the app we get /path/to/game
       pickup_bot.run(message)
-
 
       expect(a_request(:post, "https://api.telegram.org/botfake-token/sendMessage").
               with(body: {
@@ -50,7 +47,7 @@ feature "checking a game's status" do
                 "parse_mode" => "Markdown",
                 "text" => I18n.t(
                   "bot.commands.status.game_status",
-                  game_url: game_url, # this test fails on the interpolated game_url.
+                  game_url: game_url(game),
                   players: "0 / 5"
                 )
               }

--- a/spec/lib/pickup_bot/commands/status_spec.rb
+++ b/spec/lib/pickup_bot/commands/status_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+require 'telegram/bot'
+require 'pickup_bot'
+
+feature "checking a game's status" do
+  let(:bot) { Telegram::Bot::Client.new('fake-token') }
+  let(:pickup_bot) { PickupBot.new(bot) }
+  let(:telegram_user) { Telegram::Bot::Types::User.new(user_params) }
+  let(:telegram_chat) { Telegram::Bot::Types::Chat.new(chat_params) }
+  let(:existing_game) { Game.new(chat_id: fake_chat_id) }
+
+  before :each do
+    stub_request(:any, /api.telegram.org/).to_return(status: 200, body:"[]", :headers => {})
+  end
+
+  context "no game currently exists" do
+    scenario "user tries to assess the game's status" do
+      message = Telegram::Bot::Types::Message.new(message_params('/status'))
+
+      pickup_bot.run(message)
+
+      expect(a_request(:post, "https://api.telegram.org/botfake-token/sendMessage").
+              with(body: {
+                "chat_id" => "123",
+                "parse_mode" => "Markdown",
+                "text" => I18n.t(
+                  "bot.commands.status.no_game",
+                  username: user_params[:username]
+                )
+              }
+            )).to have_been_made.times(1)
+    end
+  end
+
+  context "an active game exists" do
+    scenario "user tries to assess the game's status" do
+      message = Telegram::Bot::Types::Message.new(message_params("/status"))
+      game = Game.create(chat_id: fake_chat_id, required_players: 5)
+      game.reload # to pull the UUID
+      game_url = url_for(game)
+
+      pp game_url # this outputs www.example.com/path/to/game,
+                  # but in the app we get /path/to/game
+      pickup_bot.run(message)
+
+
+      expect(a_request(:post, "https://api.telegram.org/botfake-token/sendMessage").
+              with(body: {
+                "chat_id" => "123",
+                "parse_mode" => "Markdown",
+                "text" => I18n.t(
+                  "bot.commands.status.game_status",
+                  game_url: game_url, # this test fails on the interpolated game_url.
+                  players: "0 / 5"
+                )
+              }
+            )).to have_been_made.times(1)
+    end
+  end
+end


### PR DESCRIPTION
So I'm running into two things here: 

* [x] url_for(current_game) should return `app.domain/path/to/game`, instead returns `path/to/game`. (But in the specs it returns `http://www.example.com/games/game-uuid`
* [x] we're setting `parse_mode: "markdown"` for `sendMessage`, but so far no markdown was rendered in Telegram. See [docs here](https://core.telegram.org/bots/api#markdown-style)


